### PR TITLE
Reworked utilities that use Proxy class

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sv-use/core",
-	"version": "1.0.0",
+	"version": "1.0.1",
 	"license": "MIT",
 	"description": "A collection of Svelte 5 utilities.",
 	"main": "./dist/index.js",

--- a/packages/core/src/states/auto-reset-state/index.svelte.test.ts
+++ b/packages/core/src/states/auto-reset-state/index.svelte.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { autoResetState } from './index.svelte.js';
+import { flushSync } from 'svelte';
 
 const DEFAULT_DELAY = 3000;
 const DEFAULT_CHECK_AFTER = DEFAULT_DELAY + 100;
@@ -16,59 +17,86 @@ describe('Works with primitives', () => {
 	});
 
 	it('Resets properly after the default delay', () => {
-		const message = autoResetState('');
+		const cleanup = $effect.root(() => {
+			const message = autoResetState('');
 
-		message.current = 'test';
-		expect(message.current).toBe('test');
+			flushSync(() => {
+				message.current = 'test';
+			});
 
-		vi.advanceTimersByTime(DEFAULT_CHECK_AFTER / 2);
-		expect(message.current).toBe('test');
+			expect(message.current).toBe('test');
 
-		vi.advanceTimersByTime(DEFAULT_CHECK_AFTER);
-		expect(message.current).toBe('');
+			vi.advanceTimersByTime(DEFAULT_CHECK_AFTER / 2);
+			expect(message.current).toBe('test');
+
+			vi.advanceTimersByTime(DEFAULT_CHECK_AFTER);
+			expect(message.current).toBe('');
+		});
+
+		cleanup();
 	});
 
 	it('Resets properly after a custom delay', () => {
-		const message = autoResetState('', CUSTOM_DELAY);
+		const cleanup = $effect.root(() => {
+			const message = autoResetState('', CUSTOM_DELAY);
 
-		message.current = 'test';
-		expect(message.current).toBe('test');
+			flushSync(() => {
+				message.current = 'test';
+			});
+			expect(message.current).toBe('test');
 
-		vi.advanceTimersByTime(CUSTOM_CHECK_AFTER / 2);
-		expect(message.current).toBe('test');
+			vi.advanceTimersByTime(CUSTOM_CHECK_AFTER / 2);
+			expect(message.current).toBe('test');
 
-		vi.advanceTimersByTime(CUSTOM_CHECK_AFTER);
-		expect(message.current).toBe('');
+			vi.advanceTimersByTime(CUSTOM_CHECK_AFTER);
+			expect(message.current).toBe('');
+		});
+
+		cleanup();
 	});
 
 	it('Resets properly after the default delay after multiple changes', () => {
-		const message = autoResetState('');
+		const cleanup = $effect.root(() => {
+			const message = autoResetState('');
 
-		message.current = 'test';
-		vi.advanceTimersByTime(CUSTOM_CHECK_AFTER / 2);
-		expect(message.current).toBe('test');
+			flushSync(() => {
+				message.current = 'test';
+			});
+			vi.advanceTimersByTime(CUSTOM_CHECK_AFTER / 2);
+			expect(message.current).toBe('test');
 
-		message.current = 'test2';
-		vi.advanceTimersByTime(CUSTOM_CHECK_AFTER / 2);
-		expect(message.current).toBe('test2');
+			message.current = 'test2';
+			vi.advanceTimersByTime(CUSTOM_CHECK_AFTER / 2);
+			expect(message.current).toBe('test2');
 
-		vi.advanceTimersByTime(DEFAULT_CHECK_AFTER);
-		expect(message.current).toBe('');
+			vi.advanceTimersByTime(DEFAULT_CHECK_AFTER);
+			expect(message.current).toBe('');
+		});
+
+		cleanup();
 	});
 
 	it('Resets properly after a custom delay after multiple changes', () => {
-		const message = autoResetState('', CUSTOM_DELAY);
+		const cleanup = $effect.root(() => {
+			const message = autoResetState('', CUSTOM_DELAY);
 
-		message.current = 'test';
-		vi.advanceTimersByTime(CUSTOM_CHECK_AFTER / 2);
-		expect(message.current).toBe('test');
+			flushSync(() => {
+				message.current = 'test';
+			});
+			vi.advanceTimersByTime(CUSTOM_CHECK_AFTER / 2);
+			expect(message.current).toBe('test');
 
-		message.current = 'test2';
-		vi.advanceTimersByTime(CUSTOM_CHECK_AFTER / 2);
-		expect(message.current).toBe('test2');
+			flushSync(() => {
+				message.current = 'test2';
+			});
+			vi.advanceTimersByTime(CUSTOM_CHECK_AFTER / 2);
+			expect(message.current).toBe('test2');
 
-		vi.advanceTimersByTime(CUSTOM_CHECK_AFTER);
-		expect(message.current).toBe('');
+			vi.advanceTimersByTime(CUSTOM_CHECK_AFTER);
+			expect(message.current).toBe('');
+		});
+
+		cleanup();
 	});
 });
 
@@ -82,59 +110,87 @@ describe('Works with objects', () => {
 	});
 
 	it('Resets properly after the default delay', () => {
-		const message = autoResetState({ value: '' });
+		const cleanup = $effect.root(() => {
+			const message = autoResetState({ value: '' });
 
-		message.current = { value: 'test' };
-		expect(message.current).toStrictEqual({ value: 'test' });
+			flushSync(() => {
+				message.current = { value: 'test' };
+			});
+			expect(message.current).toStrictEqual({ value: 'test' });
 
-		vi.advanceTimersByTime(DEFAULT_CHECK_AFTER / 2);
-		expect(message.current).toStrictEqual({ value: 'test' });
+			vi.advanceTimersByTime(DEFAULT_CHECK_AFTER / 2);
+			expect(message.current).toStrictEqual({ value: 'test' });
 
-		vi.advanceTimersByTime(DEFAULT_CHECK_AFTER);
-		expect(message.current).toStrictEqual({ value: '' });
+			vi.advanceTimersByTime(DEFAULT_CHECK_AFTER);
+			expect(message.current).toStrictEqual({ value: '' });
+		});
+
+		cleanup();
 	});
 
 	it('Resets properly after a custom delay', () => {
-		const message = autoResetState({ value: '' }, CUSTOM_DELAY);
+		const cleanup = $effect.root(() => {
+			const message = autoResetState({ value: '' }, CUSTOM_DELAY);
 
-		message.current = { value: 'test' };
-		expect(message.current).toStrictEqual({ value: 'test' });
+			flushSync(() => {
+				message.current = { value: 'test' };
+			});
+			expect(message.current).toStrictEqual({ value: 'test' });
 
-		vi.advanceTimersByTime(CUSTOM_CHECK_AFTER / 2);
-		expect(message.current).toStrictEqual({ value: 'test' });
+			vi.advanceTimersByTime(CUSTOM_CHECK_AFTER / 2);
+			expect(message.current).toStrictEqual({ value: 'test' });
 
-		vi.advanceTimersByTime(CUSTOM_CHECK_AFTER);
-		expect(message.current).toStrictEqual({ value: '' });
+			vi.advanceTimersByTime(CUSTOM_CHECK_AFTER);
+			expect(message.current).toStrictEqual({ value: '' });
+		});
+
+		cleanup();
 	});
 
 	it('Resets properly after the default delay after multiple changes', () => {
-		const message = autoResetState({ value: '' });
+		const cleanup = $effect.root(() => {
+			const message = autoResetState({ value: '' });
 
-		message.current = { value: 'test' };
-		vi.advanceTimersByTime(CUSTOM_CHECK_AFTER / 2);
-		expect(message.current).toStrictEqual({ value: 'test' });
+			flushSync(() => {
+				message.current = { value: 'test' };
+			});
+			vi.advanceTimersByTime(CUSTOM_CHECK_AFTER / 2);
+			expect(message.current).toStrictEqual({ value: 'test' });
 
-		message.current = { value: 'test2' };
-		vi.advanceTimersByTime(CUSTOM_CHECK_AFTER / 2);
-		expect(message.current).toStrictEqual({ value: 'test2' });
+			flushSync(() => {
+				message.current = { value: 'test2' };
+			});
+			vi.advanceTimersByTime(CUSTOM_CHECK_AFTER / 2);
+			expect(message.current).toStrictEqual({ value: 'test2' });
 
-		vi.advanceTimersByTime(DEFAULT_CHECK_AFTER);
-		expect(message.current).toStrictEqual({ value: '' });
+			vi.advanceTimersByTime(DEFAULT_CHECK_AFTER);
+			expect(message.current).toStrictEqual({ value: '' });
+		});
+
+		cleanup();
 	});
 
 	it('Resets properly after a custom delay after multiple changes', () => {
-		const message = autoResetState({ value: '' }, CUSTOM_DELAY);
+		const cleanup = $effect.root(() => {
+			const message = autoResetState({ value: '' }, CUSTOM_DELAY);
 
-		message.current = { value: 'test' };
-		vi.advanceTimersByTime(CUSTOM_CHECK_AFTER / 2);
-		expect(message.current).toStrictEqual({ value: 'test' });
+			flushSync(() => {
+				message.current = { value: 'test' };
+			});
+			vi.advanceTimersByTime(CUSTOM_CHECK_AFTER / 2);
+			expect(message.current).toStrictEqual({ value: 'test' });
 
-		message.current = { value: 'test2' };
-		vi.advanceTimersByTime(CUSTOM_CHECK_AFTER / 2);
-		expect(message.current).toStrictEqual({ value: 'test2' });
+			flushSync(() => {
+				message.current = { value: 'test2' };
+			});
+			vi.advanceTimersByTime(CUSTOM_CHECK_AFTER / 2);
+			expect(message.current).toStrictEqual({ value: 'test2' });
 
-		vi.advanceTimersByTime(CUSTOM_CHECK_AFTER);
-		expect(message.current).toStrictEqual({ value: '' });
+			vi.advanceTimersByTime(CUSTOM_CHECK_AFTER);
+			expect(message.current).toStrictEqual({ value: '' });
+		});
+
+		cleanup();
 	});
 });
 
@@ -148,58 +204,86 @@ describe('Works with property assignment on objects', () => {
 	});
 
 	it('Resets properly after the default delay', () => {
-		const message = autoResetState({ value: '' });
+		const cleanup = $effect.root(() => {
+			const message = autoResetState({ value: '' });
 
-		message.current.value = 'test';
-		expect(message.current).toStrictEqual({ value: 'test' });
+			flushSync(() => {
+				message.current.value = 'test';
+			});
+			expect(message.current).toStrictEqual({ value: 'test' });
 
-		vi.advanceTimersByTime(DEFAULT_CHECK_AFTER / 2);
-		expect(message.current).toStrictEqual({ value: 'test' });
+			vi.advanceTimersByTime(DEFAULT_CHECK_AFTER / 2);
+			expect(message.current).toStrictEqual({ value: 'test' });
 
-		vi.advanceTimersByTime(DEFAULT_CHECK_AFTER);
-		expect(message.current).toStrictEqual({ value: '' });
+			vi.advanceTimersByTime(DEFAULT_CHECK_AFTER);
+			expect(message.current).toStrictEqual({ value: '' });
+		});
+
+		cleanup();
 	});
 
 	it('Resets properly after a custom delay', () => {
-		const message = autoResetState({ value: '' }, CUSTOM_DELAY);
+		const cleanup = $effect.root(() => {
+			const message = autoResetState({ value: '' }, CUSTOM_DELAY);
 
-		message.current.value = 'test';
-		expect(message.current).toStrictEqual({ value: 'test' });
+			flushSync(() => {
+				message.current.value = 'test';
+			});
+			expect(message.current).toStrictEqual({ value: 'test' });
 
-		vi.advanceTimersByTime(CUSTOM_CHECK_AFTER / 2);
-		expect(message.current).toStrictEqual({ value: 'test' });
+			vi.advanceTimersByTime(CUSTOM_CHECK_AFTER / 2);
+			expect(message.current).toStrictEqual({ value: 'test' });
 
-		vi.advanceTimersByTime(CUSTOM_CHECK_AFTER);
-		expect(message.current).toStrictEqual({ value: '' });
+			vi.advanceTimersByTime(CUSTOM_CHECK_AFTER);
+			expect(message.current).toStrictEqual({ value: '' });
+		});
+
+		cleanup();
 	});
 
 	it('Resets properly after the default delay after multiple changes', () => {
-		const message = autoResetState({ value: '' });
+		const cleanup = $effect.root(() => {
+			const message = autoResetState({ value: '' });
 
-		message.current.value = 'test';
-		vi.advanceTimersByTime(CUSTOM_CHECK_AFTER / 2);
-		expect(message.current).toStrictEqual({ value: 'test' });
+			flushSync(() => {
+				message.current.value = 'test';
+			});
+			vi.advanceTimersByTime(CUSTOM_CHECK_AFTER / 2);
+			expect(message.current).toStrictEqual({ value: 'test' });
 
-		message.current.value = 'test2';
-		vi.advanceTimersByTime(CUSTOM_CHECK_AFTER / 2);
-		expect(message.current).toStrictEqual({ value: 'test2' });
+			flushSync(() => {
+				message.current.value = 'test2';
+			});
+			vi.advanceTimersByTime(CUSTOM_CHECK_AFTER / 2);
+			expect(message.current).toStrictEqual({ value: 'test2' });
 
-		vi.advanceTimersByTime(DEFAULT_CHECK_AFTER);
-		expect(message.current).toStrictEqual({ value: '' });
+			vi.advanceTimersByTime(DEFAULT_CHECK_AFTER);
+			expect(message.current).toStrictEqual({ value: '' });
+		});
+
+		cleanup();
 	});
 
 	it('Resets properly after a custom delay after multiple changes', () => {
-		const message = autoResetState({ value: '' }, CUSTOM_DELAY);
+		const cleanup = $effect.root(() => {
+			const message = autoResetState({ value: '' }, CUSTOM_DELAY);
 
-		message.current.value = 'test';
-		vi.advanceTimersByTime(CUSTOM_CHECK_AFTER / 2);
-		expect(message.current).toStrictEqual({ value: 'test' });
+			flushSync(() => {
+				message.current.value = 'test';
+			});
+			vi.advanceTimersByTime(CUSTOM_CHECK_AFTER / 2);
+			expect(message.current).toStrictEqual({ value: 'test' });
 
-		message.current.value = 'test2';
-		vi.advanceTimersByTime(CUSTOM_CHECK_AFTER / 2);
-		expect(message.current).toStrictEqual({ value: 'test2' });
+			flushSync(() => {
+				message.current.value = 'test2';
+			});
+			vi.advanceTimersByTime(CUSTOM_CHECK_AFTER / 2);
+			expect(message.current).toStrictEqual({ value: 'test2' });
 
-		vi.advanceTimersByTime(CUSTOM_CHECK_AFTER);
-		expect(message.current).toStrictEqual({ value: '' });
+			vi.advanceTimersByTime(CUSTOM_CHECK_AFTER);
+			expect(message.current).toStrictEqual({ value: '' });
+		});
+
+		cleanup();
 	});
 });

--- a/packages/core/src/states/local-state/index.svelte.test.ts
+++ b/packages/core/src/states/local-state/index.svelte.test.ts
@@ -1,16 +1,6 @@
+import { flushSync } from 'svelte';
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { localState } from './index.svelte.js';
-
-// Used for testing classes
-class Vector {
-	x: number;
-	y: number;
-
-	constructor(x: number, y: number) {
-		this.x = x;
-		this.y = y;
-	}
-}
 
 const ORIGINAL_WINDOW_LOCATION = window.location;
 
@@ -41,7 +31,9 @@ describe('Works with primitives', () => {
 			expect(state.current).toBe(0);
 			expect(localStorage.getItem('counter')).toBe('0');
 
-			state.current = 1;
+			flushSync(() => {
+				state.current = 1;
+			});
 			expect(state.current).toBe(1);
 			expect(localStorage.getItem('counter')).toBe('1');
 		});
@@ -56,7 +48,9 @@ describe('Works with primitives', () => {
 			expect(state.current).toBe(0);
 			expect(localStorage.getItem('counter')).toBe('0');
 
-			state.current = 1;
+			flushSync(() => {
+				state.current = 1;
+			});
 			expect(state.current).toBe(1);
 			expect(localStorage.getItem('counter')).toBe('1');
 
@@ -76,15 +70,21 @@ describe('Works with primitives', () => {
 			expect(state.current).toBe(0);
 			expect(localStorage.getItem('counter')).toBe('0');
 
-			state.current = 1;
+			flushSync(() => {
+				state.current = 1;
+			});
 			expect(state.current).toBe(1);
 			expect(localStorage.getItem('counter')).toBe('1');
 
-			state.current = 2;
+			flushSync(() => {
+				state.current = 2;
+			});
 			expect(state.current).toBe(2);
 			expect(localStorage.getItem('counter')).toBe('2');
 
-			state.current = 3;
+			flushSync(() => {
+				state.current = 3;
+			});
 			expect(state.current).toBe(3);
 			expect(localStorage.getItem('counter')).toBe('3');
 		});
@@ -161,7 +161,9 @@ describe('Works with objects', () => {
 			expect(state.current).toStrictEqual({ value: 0 });
 			expect(localStorage.getItem('counter')).toBe('{"value":0}');
 
-			state.current = { value: 1 };
+			flushSync(() => {
+				state.current = { value: 1 };
+			});
 			expect(state.current).toStrictEqual({ value: 1 });
 			expect(localStorage.getItem('counter')).toBe('{"value":1}');
 		});
@@ -176,7 +178,9 @@ describe('Works with objects', () => {
 			expect(state.current).toStrictEqual({ value: 0 });
 			expect(localStorage.getItem('counter')).toBe('{"value":0}');
 
-			state.current = { value: 1 };
+			flushSync(() => {
+				state.current = { value: 1 };
+			});
 			expect(state.current).toStrictEqual({ value: 1 });
 			expect(localStorage.getItem('counter')).toBe('{"value":1}');
 
@@ -196,15 +200,21 @@ describe('Works with objects', () => {
 			expect(state.current).toStrictEqual({ value: 0 });
 			expect(localStorage.getItem('counter')).toBe('{"value":0}');
 
-			state.current = { value: 1 };
+			flushSync(() => {
+				state.current = { value: 1 };
+			});
 			expect(state.current).toStrictEqual({ value: 1 });
 			expect(localStorage.getItem('counter')).toBe('{"value":1}');
 
-			state.current = { value: 2 };
+			flushSync(() => {
+				state.current = { value: 2 };
+			});
 			expect(state.current).toStrictEqual({ value: 2 });
 			expect(localStorage.getItem('counter')).toBe('{"value":2}');
 
-			state.current = { value: 3 };
+			flushSync(() => {
+				state.current = { value: 3 };
+			});
 			expect(state.current).toStrictEqual({ value: 3 });
 			expect(localStorage.getItem('counter')).toBe('{"value":3}');
 		});
@@ -252,7 +262,9 @@ describe('Works with property assignment on objects', () => {
 			expect(state.current).toStrictEqual({ value: 0 });
 			expect(localStorage.getItem('counter')).toBe('{"value":0}');
 
-			state.current.value = 1;
+			flushSync(() => {
+				state.current.value = 1;
+			});
 			expect(state.current).toStrictEqual({ value: 1 });
 			expect(localStorage.getItem('counter')).toBe('{"value":1}');
 		});
@@ -267,7 +279,9 @@ describe('Works with property assignment on objects', () => {
 			expect(state.current).toStrictEqual({ value: 0 });
 			expect(localStorage.getItem('counter')).toBe('{"value":0}');
 
-			state.current.value = 1;
+			flushSync(() => {
+				state.current.value = 1;
+			});
 			expect(state.current).toStrictEqual({ value: 1 });
 			expect(localStorage.getItem('counter')).toBe('{"value":1}');
 
@@ -287,15 +301,21 @@ describe('Works with property assignment on objects', () => {
 			expect(state.current).toStrictEqual({ value: 0 });
 			expect(localStorage.getItem('counter')).toBe('{"value":0}');
 
-			state.current.value = 1;
+			flushSync(() => {
+				state.current.value = 1;
+			});
 			expect(state.current).toStrictEqual({ value: 1 });
 			expect(localStorage.getItem('counter')).toBe('{"value":1}');
 
-			state.current.value = 2;
+			flushSync(() => {
+				state.current.value = 2;
+			});
 			expect(state.current).toStrictEqual({ value: 2 });
 			expect(localStorage.getItem('counter')).toBe('{"value":2}');
 
-			state.current.value = 3;
+			flushSync(() => {
+				state.current.value = 3;
+			});
 			expect(state.current).toStrictEqual({ value: 3 });
 			expect(localStorage.getItem('counter')).toBe('{"value":3}');
 		});
@@ -331,7 +351,9 @@ describe('Works with arrays', () => {
 			expect(state.current).toStrictEqual([]);
 			expect(localStorage.getItem('counter')).toBe('[]');
 
-			state.current = [1];
+			flushSync(() => {
+				state.current = [1];
+			});
 			expect(state.current).toStrictEqual([1]);
 			expect(localStorage.getItem('counter')).toBe('[1]');
 		});
@@ -346,7 +368,9 @@ describe('Works with arrays', () => {
 			expect(state.current).toStrictEqual([]);
 			expect(localStorage.getItem('counter')).toBe('[]');
 
-			state.current = [1];
+			flushSync(() => {
+				state.current = [1];
+			});
 			expect(state.current).toStrictEqual([1]);
 			expect(localStorage.getItem('counter')).toBe('[1]');
 
@@ -366,15 +390,21 @@ describe('Works with arrays', () => {
 			expect(state.current).toStrictEqual([]);
 			expect(localStorage.getItem('counter')).toBe('[]');
 
-			state.current = [1];
+			flushSync(() => {
+				state.current = [1];
+			});
 			expect(state.current).toStrictEqual([1]);
 			expect(localStorage.getItem('counter')).toBe('[1]');
 
-			state.current = [2];
+			flushSync(() => {
+				state.current = [2];
+			});
 			expect(state.current).toStrictEqual([2]);
 			expect(localStorage.getItem('counter')).toBe('[2]');
 
-			state.current = [3];
+			flushSync(() => {
+				state.current = [3];
+			});
 			expect(state.current).toStrictEqual([3]);
 			expect(localStorage.getItem('counter')).toBe('[3]');
 		});
@@ -422,7 +452,9 @@ describe('Works with array methods', () => {
 			expect(state.current).toStrictEqual([]);
 			expect(localStorage.getItem('counter')).toBe('[]');
 
-			state.current.push(1);
+			flushSync(() => {
+				state.current.push(1);
+			});
 			expect(state.current).toStrictEqual([1]);
 			expect(localStorage.getItem('counter')).toBe('[1]');
 		});
@@ -437,7 +469,9 @@ describe('Works with array methods', () => {
 			expect(state.current).toStrictEqual([]);
 			expect(localStorage.getItem('counter')).toBe('[]');
 
-			state.current.push(1);
+			flushSync(() => {
+				state.current.push(1);
+			});
 			expect(state.current).toStrictEqual([1]);
 			expect(localStorage.getItem('counter')).toBe('[1]');
 
@@ -457,15 +491,21 @@ describe('Works with array methods', () => {
 			expect(state.current).toStrictEqual([]);
 			expect(localStorage.getItem('counter')).toBe('[]');
 
-			state.current.push(1);
+			flushSync(() => {
+				state.current.push(1);
+			});
 			expect(state.current).toStrictEqual([1]);
 			expect(localStorage.getItem('counter')).toBe('[1]');
 
-			state.current.push(2);
+			flushSync(() => {
+				state.current.push(2);
+			});
 			expect(state.current).toStrictEqual([1, 2]);
 			expect(localStorage.getItem('counter')).toBe('[1,2]');
 
-			state.current.push(3);
+			flushSync(() => {
+				state.current.push(3);
+			});
 			expect(state.current).toStrictEqual([1, 2, 3]);
 			expect(localStorage.getItem('counter')).toBe('[1,2,3]');
 		});
@@ -480,109 +520,6 @@ describe('Works with array methods', () => {
 			const state = localState('counter', [] as number[]);
 
 			expect(state.current).toStrictEqual([1]);
-		});
-
-		cleanup();
-	});
-});
-
-describe('Works with classes', () => {
-	beforeEach(() => {
-		localStorage.clear();
-	});
-
-	beforeAll(() => {
-		/** @see https://stackoverflow.com/a/55771671/20892950 */
-		Object.defineProperty(window, 'location', {
-			configurable: true,
-			value: { reload: vi.fn(() => {}) }
-		});
-	});
-
-	afterAll(() => {
-		Object.defineProperty(window, 'location', {
-			configurable: true,
-			value: ORIGINAL_WINDOW_LOCATION
-		});
-	});
-
-	it('Persists state correctly', () => {
-		const cleanup = $effect.root(() => {
-			const state = localState('vector', new Vector(0, 0), {
-				serialize: (value) => JSON.stringify([value.x, value.y]),
-				deserialize: (value) => new Vector(...(JSON.parse(value) as [number, number]))
-			});
-
-			expect(state.current).toStrictEqual(new Vector(0, 0));
-			expect(localStorage.getItem('vector')).toBe('[0,0]');
-
-			state.current.x = 1;
-			expect(state.current).toStrictEqual(new Vector(1, 0));
-			expect(localStorage.getItem('vector')).toBe('[1,0]');
-		});
-
-		cleanup();
-	});
-
-	it('Persists state correctly after reload', () => {
-		const cleanup = $effect.root(() => {
-			const state = localState('vector', new Vector(0, 0), {
-				serialize: (value) => JSON.stringify([value.x, value.y]),
-				deserialize: (value) => new Vector(...(JSON.parse(value) as [number, number]))
-			});
-
-			expect(state.current).toStrictEqual(new Vector(0, 0));
-			expect(localStorage.getItem('vector')).toBe('[0,0]');
-
-			state.current.x = 1;
-			expect(state.current).toStrictEqual(new Vector(1, 0));
-			expect(localStorage.getItem('vector')).toBe('[1,0]');
-
-			window.location.reload();
-
-			expect(state.current).toStrictEqual(new Vector(1, 0));
-			expect(localStorage.getItem('vector')).toBe('[1,0]');
-		});
-
-		cleanup();
-	});
-
-	it('Persists state correctly after multiple changes', () => {
-		const cleanup = $effect.root(() => {
-			const state = localState('vector', new Vector(0, 0), {
-				serialize: (value) => JSON.stringify([value.x, value.y]),
-				deserialize: (value) => new Vector(...(JSON.parse(value) as [number, number]))
-			});
-
-			expect(state.current).toStrictEqual(new Vector(0, 0));
-			expect(localStorage.getItem('vector')).toBe('[0,0]');
-
-			state.current.x = 1;
-			expect(state.current).toStrictEqual(new Vector(1, 0));
-			expect(localStorage.getItem('vector')).toBe('[1,0]');
-
-			state.current.x = 2;
-			expect(state.current).toStrictEqual(new Vector(2, 0));
-			expect(localStorage.getItem('vector')).toBe('[2,0]');
-
-			state.current.x = 3;
-			expect(state.current).toStrictEqual(new Vector(3, 0));
-			expect(localStorage.getItem('vector')).toBe('[3,0]');
-		});
-
-		cleanup();
-	});
-
-	it('Retrieves initial state from local storage correctly', () => {
-		const cleanup = $effect.root(() => {
-			localStorage.setItem('vector', '[1,2]');
-
-			const state = localState('vector', new Vector(0, 0), {
-				serialize: (value) => JSON.stringify([value.x, value.y]),
-				deserialize: (value) => new Vector(...(JSON.parse(value) as [number, number]))
-			});
-
-			expect(state.current).toStrictEqual(new Vector(1, 2));
 		});
 
 		cleanup();

--- a/packages/core/src/states/local-state/index.svelte.ts
+++ b/packages/core/src/states/local-state/index.svelte.ts
@@ -30,27 +30,9 @@ export function localState<T>(key: string, value: T, options: LocalStateOptions<
 		}
 	}
 
-	const handler: ProxyHandler<{ current: T }> = {
-		get(target: Record<string, unknown>, key: string) {
-			if (
-				target &&
-				typeof target === 'object' &&
-				typeof target[key] === 'object' &&
-				target[key] !== null
-			) {
-				return new Proxy(target[key], handler);
-			} else {
-				return target[key];
-			}
-		},
-		set(target: Record<string, unknown>, proxyKey: string, proxyValue: unknown) {
-			target[proxyKey] = proxyValue;
+	$effect(() => {
+		localStorage.setItem(key, serialize(_state.current));
+	});
 
-			localStorage.setItem(key, serialize(_state.current));
-
-			return true;
-		}
-	};
-
-	return new Proxy(_state, handler);
+	return _state;
 }

--- a/packages/core/src/states/session-state/index.svelte.test.ts
+++ b/packages/core/src/states/session-state/index.svelte.test.ts
@@ -1,16 +1,6 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { sessionState } from './index.svelte.js';
-
-// Used for testing classes
-class Vector {
-	x: number;
-	y: number;
-
-	constructor(x: number, y: number) {
-		this.x = x;
-		this.y = y;
-	}
-}
+import { flushSync } from 'svelte';
 
 const ORIGINAL_WINDOW_LOCATION = window.location;
 
@@ -41,7 +31,9 @@ describe('Works with primitives', () => {
 			expect(state.current).toBe(0);
 			expect(sessionStorage.getItem('counter')).toBe('0');
 
-			state.current = 1;
+			flushSync(() => {
+				state.current = 1;
+			});
 			expect(state.current).toBe(1);
 			expect(sessionStorage.getItem('counter')).toBe('1');
 		});
@@ -56,7 +48,9 @@ describe('Works with primitives', () => {
 			expect(state.current).toBe(0);
 			expect(sessionStorage.getItem('counter')).toBe('0');
 
-			state.current = 1;
+			flushSync(() => {
+				state.current = 1;
+			});
 			expect(state.current).toBe(1);
 			expect(sessionStorage.getItem('counter')).toBe('1');
 
@@ -76,15 +70,21 @@ describe('Works with primitives', () => {
 			expect(state.current).toBe(0);
 			expect(sessionStorage.getItem('counter')).toBe('0');
 
-			state.current = 1;
+			flushSync(() => {
+				state.current = 1;
+			});
 			expect(state.current).toBe(1);
 			expect(sessionStorage.getItem('counter')).toBe('1');
 
-			state.current = 2;
+			flushSync(() => {
+				state.current = 2;
+			});
 			expect(state.current).toBe(2);
 			expect(sessionStorage.getItem('counter')).toBe('2');
 
-			state.current = 3;
+			flushSync(() => {
+				state.current = 3;
+			});
 			expect(state.current).toBe(3);
 			expect(sessionStorage.getItem('counter')).toBe('3');
 		});
@@ -161,7 +161,9 @@ describe('Works with objects', () => {
 			expect(state.current).toStrictEqual({ value: 0 });
 			expect(sessionStorage.getItem('counter')).toBe('{"value":0}');
 
-			state.current = { value: 1 };
+			flushSync(() => {
+				state.current = { value: 1 };
+			});
 			expect(state.current).toStrictEqual({ value: 1 });
 			expect(sessionStorage.getItem('counter')).toBe('{"value":1}');
 		});
@@ -176,7 +178,9 @@ describe('Works with objects', () => {
 			expect(state.current).toStrictEqual({ value: 0 });
 			expect(sessionStorage.getItem('counter')).toBe('{"value":0}');
 
-			state.current = { value: 1 };
+			flushSync(() => {
+				state.current = { value: 1 };
+			});
 			expect(state.current).toStrictEqual({ value: 1 });
 			expect(sessionStorage.getItem('counter')).toBe('{"value":1}');
 
@@ -196,15 +200,21 @@ describe('Works with objects', () => {
 			expect(state.current).toStrictEqual({ value: 0 });
 			expect(sessionStorage.getItem('counter')).toBe('{"value":0}');
 
-			state.current = { value: 1 };
+			flushSync(() => {
+				state.current = { value: 1 };
+			});
 			expect(state.current).toStrictEqual({ value: 1 });
 			expect(sessionStorage.getItem('counter')).toBe('{"value":1}');
 
-			state.current = { value: 2 };
+			flushSync(() => {
+				state.current = { value: 2 };
+			});
 			expect(state.current).toStrictEqual({ value: 2 });
 			expect(sessionStorage.getItem('counter')).toBe('{"value":2}');
 
-			state.current = { value: 3 };
+			flushSync(() => {
+				state.current = { value: 3 };
+			});
 			expect(state.current).toStrictEqual({ value: 3 });
 			expect(sessionStorage.getItem('counter')).toBe('{"value":3}');
 		});
@@ -252,7 +262,9 @@ describe('Works with property assignment on objects', () => {
 			expect(state.current).toStrictEqual({ value: 0 });
 			expect(sessionStorage.getItem('counter')).toBe('{"value":0}');
 
-			state.current.value = 1;
+			flushSync(() => {
+				state.current.value = 1;
+			});
 			expect(state.current).toStrictEqual({ value: 1 });
 			expect(sessionStorage.getItem('counter')).toBe('{"value":1}');
 		});
@@ -267,7 +279,9 @@ describe('Works with property assignment on objects', () => {
 			expect(state.current).toStrictEqual({ value: 0 });
 			expect(sessionStorage.getItem('counter')).toBe('{"value":0}');
 
-			state.current.value = 1;
+			flushSync(() => {
+				state.current.value = 1;
+			});
 			expect(state.current).toStrictEqual({ value: 1 });
 			expect(sessionStorage.getItem('counter')).toBe('{"value":1}');
 
@@ -287,15 +301,21 @@ describe('Works with property assignment on objects', () => {
 			expect(state.current).toStrictEqual({ value: 0 });
 			expect(sessionStorage.getItem('counter')).toBe('{"value":0}');
 
-			state.current.value = 1;
+			flushSync(() => {
+				state.current.value = 1;
+			});
 			expect(state.current).toStrictEqual({ value: 1 });
 			expect(sessionStorage.getItem('counter')).toBe('{"value":1}');
 
-			state.current.value = 2;
+			flushSync(() => {
+				state.current.value = 2;
+			});
 			expect(state.current).toStrictEqual({ value: 2 });
 			expect(sessionStorage.getItem('counter')).toBe('{"value":2}');
 
-			state.current.value = 3;
+			flushSync(() => {
+				state.current.value = 3;
+			});
 			expect(state.current).toStrictEqual({ value: 3 });
 			expect(sessionStorage.getItem('counter')).toBe('{"value":3}');
 		});
@@ -331,7 +351,9 @@ describe('Works with arrays', () => {
 			expect(state.current).toStrictEqual([]);
 			expect(sessionStorage.getItem('counter')).toBe('[]');
 
-			state.current = [1];
+			flushSync(() => {
+				state.current = [1];
+			});
 			expect(state.current).toStrictEqual([1]);
 			expect(sessionStorage.getItem('counter')).toBe('[1]');
 		});
@@ -346,7 +368,9 @@ describe('Works with arrays', () => {
 			expect(state.current).toStrictEqual([]);
 			expect(sessionStorage.getItem('counter')).toBe('[]');
 
-			state.current = [1];
+			flushSync(() => {
+				state.current = [1];
+			});
 			expect(state.current).toStrictEqual([1]);
 			expect(sessionStorage.getItem('counter')).toBe('[1]');
 
@@ -366,15 +390,21 @@ describe('Works with arrays', () => {
 			expect(state.current).toStrictEqual([]);
 			expect(sessionStorage.getItem('counter')).toBe('[]');
 
-			state.current = [1];
+			flushSync(() => {
+				state.current = [1];
+			});
 			expect(state.current).toStrictEqual([1]);
 			expect(sessionStorage.getItem('counter')).toBe('[1]');
 
-			state.current = [2];
+			flushSync(() => {
+				state.current = [2];
+			});
 			expect(state.current).toStrictEqual([2]);
 			expect(sessionStorage.getItem('counter')).toBe('[2]');
 
-			state.current = [3];
+			flushSync(() => {
+				state.current = [3];
+			});
 			expect(state.current).toStrictEqual([3]);
 			expect(sessionStorage.getItem('counter')).toBe('[3]');
 		});
@@ -422,7 +452,9 @@ describe('Works with array methods', () => {
 			expect(state.current).toStrictEqual([]);
 			expect(sessionStorage.getItem('counter')).toBe('[]');
 
-			state.current.push(1);
+			flushSync(() => {
+				state.current.push(1);
+			});
 			expect(state.current).toStrictEqual([1]);
 			expect(sessionStorage.getItem('counter')).toBe('[1]');
 		});
@@ -437,7 +469,9 @@ describe('Works with array methods', () => {
 			expect(state.current).toStrictEqual([]);
 			expect(sessionStorage.getItem('counter')).toBe('[]');
 
-			state.current.push(1);
+			flushSync(() => {
+				state.current.push(1);
+			});
 			expect(state.current).toStrictEqual([1]);
 			expect(sessionStorage.getItem('counter')).toBe('[1]');
 
@@ -457,15 +491,21 @@ describe('Works with array methods', () => {
 			expect(state.current).toStrictEqual([]);
 			expect(sessionStorage.getItem('counter')).toBe('[]');
 
-			state.current.push(1);
+			flushSync(() => {
+				state.current.push(1);
+			});
 			expect(state.current).toStrictEqual([1]);
 			expect(sessionStorage.getItem('counter')).toBe('[1]');
 
-			state.current.push(2);
+			flushSync(() => {
+				state.current.push(2);
+			});
 			expect(state.current).toStrictEqual([1, 2]);
 			expect(sessionStorage.getItem('counter')).toBe('[1,2]');
 
-			state.current.push(3);
+			flushSync(() => {
+				state.current.push(3);
+			});
 			expect(state.current).toStrictEqual([1, 2, 3]);
 			expect(sessionStorage.getItem('counter')).toBe('[1,2,3]');
 		});
@@ -480,109 +520,6 @@ describe('Works with array methods', () => {
 			const state = sessionState('counter', [] as number[]);
 
 			expect(state.current).toStrictEqual([1]);
-		});
-
-		cleanup();
-	});
-});
-
-describe('Works with classes', () => {
-	beforeEach(() => {
-		sessionStorage.clear();
-	});
-
-	beforeAll(() => {
-		/** @see https://stackoverflow.com/a/55771671/20892950 */
-		Object.defineProperty(window, 'location', {
-			configurable: true,
-			value: { reload: vi.fn(() => {}) }
-		});
-	});
-
-	afterAll(() => {
-		Object.defineProperty(window, 'location', {
-			configurable: true,
-			value: ORIGINAL_WINDOW_LOCATION
-		});
-	});
-
-	it('Persists state correctly', () => {
-		const cleanup = $effect.root(() => {
-			const state = sessionState('vector', new Vector(0, 0), {
-				serialize: (value) => JSON.stringify([value.x, value.y]),
-				deserialize: (value) => new Vector(...(JSON.parse(value) as [number, number]))
-			});
-
-			expect(state.current).toStrictEqual(new Vector(0, 0));
-			expect(sessionStorage.getItem('vector')).toBe('[0,0]');
-
-			state.current.x = 1;
-			expect(state.current).toStrictEqual(new Vector(1, 0));
-			expect(sessionStorage.getItem('vector')).toBe('[1,0]');
-		});
-
-		cleanup();
-	});
-
-	it('Persists state correctly after reload', () => {
-		const cleanup = $effect.root(() => {
-			const state = sessionState('vector', new Vector(0, 0), {
-				serialize: (value) => JSON.stringify([value.x, value.y]),
-				deserialize: (value) => new Vector(...(JSON.parse(value) as [number, number]))
-			});
-
-			expect(state.current).toStrictEqual(new Vector(0, 0));
-			expect(sessionStorage.getItem('vector')).toBe('[0,0]');
-
-			state.current.x = 1;
-			expect(state.current).toStrictEqual(new Vector(1, 0));
-			expect(sessionStorage.getItem('vector')).toBe('[1,0]');
-
-			window.location.reload();
-
-			expect(state.current).toStrictEqual(new Vector(1, 0));
-			expect(sessionStorage.getItem('vector')).toBe('[1,0]');
-		});
-
-		cleanup();
-	});
-
-	it('Persists state correctly after multiple changes', () => {
-		const cleanup = $effect.root(() => {
-			const state = sessionState('vector', new Vector(0, 0), {
-				serialize: (value) => JSON.stringify([value.x, value.y]),
-				deserialize: (value) => new Vector(...(JSON.parse(value) as [number, number]))
-			});
-
-			expect(state.current).toStrictEqual(new Vector(0, 0));
-			expect(sessionStorage.getItem('vector')).toBe('[0,0]');
-
-			state.current.x = 1;
-			expect(state.current).toStrictEqual(new Vector(1, 0));
-			expect(sessionStorage.getItem('vector')).toBe('[1,0]');
-
-			state.current.x = 2;
-			expect(state.current).toStrictEqual(new Vector(2, 0));
-			expect(sessionStorage.getItem('vector')).toBe('[2,0]');
-
-			state.current.x = 3;
-			expect(state.current).toStrictEqual(new Vector(3, 0));
-			expect(sessionStorage.getItem('vector')).toBe('[3,0]');
-		});
-
-		cleanup();
-	});
-
-	it('Retrieves initial state from local storage correctly', () => {
-		const cleanup = $effect.root(() => {
-			sessionStorage.setItem('vector', '[1,2]');
-
-			const state = sessionState('vector', new Vector(0, 0), {
-				serialize: (value) => JSON.stringify([value.x, value.y]),
-				deserialize: (value) => new Vector(...(JSON.parse(value) as [number, number]))
-			});
-
-			expect(state.current).toStrictEqual(new Vector(1, 2));
 		});
 
 		cleanup();

--- a/packages/core/src/states/session-state/index.svelte.ts
+++ b/packages/core/src/states/session-state/index.svelte.ts
@@ -30,27 +30,9 @@ export function sessionState<T>(key: string, value: T, options: SessionStateOpti
 		}
 	}
 
-	const handler: ProxyHandler<{ current: T }> = {
-		get(target: Record<string, unknown>, key: string) {
-			if (
-				target &&
-				typeof target === 'object' &&
-				typeof target[key] === 'object' &&
-				target[key] !== null
-			) {
-				return new Proxy(target[key], handler);
-			} else {
-				return target[key];
-			}
-		},
-		set(target: Record<string, unknown>, proxyKey: string, proxyValue: unknown) {
-			target[proxyKey] = proxyValue;
+	$effect(() => {
+		sessionStorage.setItem(key, serialize(_state.current));
+	});
 
-			sessionStorage.setItem(key, serialize(_state.current));
-
-			return true;
-		}
-	};
-
-	return new Proxy(_state, handler);
+	return _state;
 }


### PR DESCRIPTION
Using normal `$effect` for `autoResetState`, `localState` and `sessionState`.

Cannot do it for `debouncedState` and `defaultState` as it requires intercepting the change itself.